### PR TITLE
switched continue shopping to go to products instead of landing page

### DIFF
--- a/client/src/components/HeaderCheckout.js
+++ b/client/src/components/HeaderCheckout.js
@@ -8,7 +8,7 @@ const HeaderCheckout = (props) => {
 
   return (
     <header>
-      <Link to='/'>Continue Shopping</Link>
+      <Link to='/products'>Continue Shopping</Link>
       <h1><Logo /></h1>
       {user !== '' ? <span className='welcome'>Welcome, {user}</span> : null }
     </header>


### PR DESCRIPTION
Hey peeps...

All I did was change the route when you press the "continue shopping" link. I sent it to go to products instead of "/"